### PR TITLE
[ME-1896] Update CFN for AWS Connector Installer

### DIFF
--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -22,6 +22,21 @@ Parameters:
     Type: AWS::SSM::Parameter::Name
     Description: The name/path of the SSM parameter for the Border0 token (which the connector instance uses to authenticate against your Border0 organization)
 
+  Border0LogLevel:
+    Type: String
+    Description: The minimum severity level of events to log
+    Default: info
+
+  Border0ConnectorServer:
+    Type: String
+    Description: The host and port of the Border0 connector control plane GRPC server.
+    Default: capi.border0.com:443
+
+  Border0TunnelServer:
+    Type: String
+    Description: The host and port of the Border0 connector data plane tunnel server.
+    Default: tunnel.border0.com
+
 ####################################
 ##           RESOURCES            ##
 ####################################
@@ -40,7 +55,30 @@ Resources:
               - 'sts:AssumeRole'
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess'
+        - 'arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess'
       Policies:
+        # ECS ReadOnly Policy for ECS discovery and providing Border0 clients
+        # with the menu with all available tasks and containers in ecs service.
+        - PolicyName: AmazonECSReadOnlyAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ecs:DescribeClusters'
+                  - 'ecs:DescribeContainerInstances'
+                  - 'ecs:DescribeServices'
+                  - 'ecs:DescribeTaskDefinition'
+                  - 'ecs:DescribeTasks'
+                  - 'ecs:ListClusters'
+                  - 'ecs:ListContainerInstances'
+                  - 'ecs:ListServices'
+                  - 'ecs:ListTaskDefinitionFamilies'
+                  - 'ecs:ListTaskDefinitions'
+                  - 'ecs:ListTasks'
+                Resource: '*'
+        # SSM Parameter ReadOnly access to the SSM parameter of the connector's token.
         - PolicyName: AccessToBorder0TokenSsmParameter
           PolicyDocument:
             Version: '2012-10-17'
@@ -49,10 +87,32 @@ Resources:
                 Action: 'ssm:DescribeParameters'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
               - Effect: Allow
-                Action: 
+                Action:
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Border0TokenSsmParameter}'
+        # Allow sending public keys to any ec2 instance (for ec2 instance connect).
+        - PolicyName: SendSshPublicKeysToEc2Instances
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:SendSSHPublicKey'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+        # Allow starting and terminating ssm sessions to any instance (for ssm)
+        - PolicyName: StartAndTerminateSsmSessions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ssm:StartSession'
+                Resource:
+                  - !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+                  - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession'
+              - Effect: Allow
+                Action: 'ssm:TerminateSession'
+                Resource:
+                  - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:session/*'
 
   ConnectorInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -73,7 +133,7 @@ Resources:
     Type: 'AWS::AutoScaling::LaunchConfiguration'
     Properties:
       IamInstanceProfile: !Ref ConnectorInstanceProfile
-      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64}}'
+      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
       InstanceType: !Ref InstanceType
       SecurityGroups:
         - !Ref ConnectorInstanceSecurityGroup
@@ -82,23 +142,14 @@ Resources:
         Fn::Base64:
           !Sub |
             #!/bin/bash -xe
-
             sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
             sudo chmod +x /usr/local/bin/border0
-
-            cat << EOF > border0.yaml
-            connector:
-              name: aws-install-wizard-connector
-              ssm-aws-region: ${AWS::Region}
-            credentials:
-              token: aws:ssm:${Border0TokenSsmParameter}
-            sockets:
-              - aws-install-wizard-connector:
-                  type: ssh
-                  sshserver: true
-            EOF
-
-            border0 connector start --config border0.yaml
+            export AWS_REGION=${AWS::Region}
+            export BORDER0_TOKEN=from:aws:ssm:${Border0TokenSsmParameter}
+            export BORDER0_TUNNEL=${Border0TunnelServer}
+            export BORDER0_CONNECTOR_SERVER=${Border0ConnectorServer}
+            export BORDER0_LOG_LEVEL=${Border0LogLevel}
+            border0 connector start --v2
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'


### PR DESCRIPTION
## [[ME-1895](https://mysocket.atlassian.net/browse/ME-1895)][[ME-1896](https://mysocket.atlassian.net/browse/ME-1896)] Connector V2 Cloud Installer Improvements

- Uses the (normal) AL 2023 AMI, instead of the minimal one (minimal does not have ec2 instance connect script)
- Adds permission to push ssh public keys to all ec2 instances in the account
- Adds permission to allow starting and terminating SSM sessions to all ec2 instances in the account

Fixes:
- https://mysocket.atlassian.net/browse/ME-1895
- https://mysocket.atlassian.net/browse/ME-1896

[ME-1895]: https://mysocket.atlassian.net/browse/ME-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ME-1896]: https://mysocket.atlassian.net/browse/ME-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ