### PR TITLE
[ME-1898] Run SSM Agent in AWS-Installer Connector Instances

### DIFF
--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -22,21 +22,6 @@ Parameters:
     Type: AWS::SSM::Parameter::Name
     Description: The name/path of the SSM parameter for the Border0 token (which the connector instance uses to authenticate against your Border0 organization)
 
-  Border0LogLevel:
-    Type: String
-    Description: The minimum severity level of events to log
-    Default: info
-
-  Border0ConnectorServer:
-    Type: String
-    Description: The host and port of the Border0 connector control plane GRPC server.
-    Default: capi.border0.com:443
-
-  Border0TunnelServer:
-    Type: String
-    Description: The host and port of the Border0 connector data plane tunnel server.
-    Default: tunnel.border0.com
-
 ####################################
 ##           RESOURCES            ##
 ####################################
@@ -56,7 +41,7 @@ Resources:
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess'
         - 'arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess'
-        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedEC2InstanceDefaultPolicy' # allows SSM access to connector instances as breakglass
       Policies:
         # ECS ReadOnly Policy for ECS discovery and providing Border0 clients
         # with the menu with all available tasks and containers in ecs service.
@@ -113,6 +98,14 @@ Resources:
                 Action: 'ssm:TerminateSession'
                 Resource:
                   - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:session/*'
+        # Allow the EC2 discoverer to check EC2 instances' SSM status (e.g. registered with ssm or not)
+        - PolicyName: DescribeInstancesSsmStatus
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ssm:DescribeInstanceInformation'
+                Resource: !Sub 'arn:aws:ssm:*:${AWS::AccountId}:*'
 
   ConnectorInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -146,9 +139,6 @@ Resources:
             sudo chmod +x /usr/local/bin/border0
             export AWS_REGION=${AWS::Region}
             export BORDER0_TOKEN=from:aws:ssm:${Border0TokenSsmParameter}
-            export BORDER0_TUNNEL=${Border0TunnelServer}
-            export BORDER0_CONNECTOR_SERVER=${Border0ConnectorServer}
-            export BORDER0_LOG_LEVEL=${Border0LogLevel}
             border0 connector start --v2
 
   ConnectorInstanceAutoScalingGroup:


### PR DESCRIPTION
## [ME-1898] Run SSM Agent in AWS-Installer Connector Instances

See https://github.com/borderzero/border0-cli/pull/192 for more

[ME-1898]: https://mysocket.atlassian.net/browse/ME-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ