### PR TITLE
[ME-1898]  Allow Connector To Generate Creds for RDS DB

### DIFF
--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -92,6 +92,7 @@ Resources:
               - Effect: Allow
                 Action: 'ssm:StartSession'
                 Resource:
+                  - !Sub 'arn:aws:ecs:*:${AWS::AccountId}:task/*'
                   - !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
                   - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession'
               - Effect: Allow

--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -76,6 +76,14 @@ Resources:
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Border0TokenSsmParameter}'
+        # Allow generating temporary user credentials for database IAM access.
+        - PolicyName: GenerateTemporaryDatabaseCredsForRds
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'rds-db:connect'
+                Resource: !Sub 'arn:aws:rds-db:*:${AWS::AccountId}:dbuser:*'
         # Allow sending public keys to any ec2 instance (for ec2 instance connect).
         - PolicyName: SendSshPublicKeysToEc2Instances
           PolicyDocument:
@@ -138,9 +146,7 @@ Resources:
             #!/bin/bash -xe
             sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
             sudo chmod +x /usr/local/bin/border0
-            export AWS_REGION=${AWS::Region}
-            export BORDER0_TOKEN=from:aws:ssm:${Border0TokenSsmParameter}
-            border0 connector start --v2
+            sudo border0 connector install --v2 --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'


### PR DESCRIPTION
## [[ME-1898](https://mysocket.atlassian.net/browse/ME-1830)] Allow Connector To Generate Creds for RDS DB

- Also adds ability to start ssm sessions against any ECS task.
- Also installs connector systemd unit in instance (instead of just running it).

[ME-1898]: https://mysocket.atlassian.net/browse/ME-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ