### PR TITLE
[ME-2998] Add List Services Permissions to Connector K8S

### DIFF
--- a/kubernetes-templates/connector_in_k8s/connector.yaml
+++ b/kubernetes-templates/connector_in_k8s/connector.yaml
@@ -13,9 +13,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: border0-connector
 rules:
-  # rule for connector to list namespaces and pods
+  # rule for connector to list namespaces, services, and pods
   - apiGroups: [""]
-    resources: ["namespaces", "pods"]
+    resources: ["namespaces", "services", "pods"]
     verbs: ["list"]
   # rule for connector to get pods (incl. its containers)
   - apiGroups: [""]


### PR DESCRIPTION
## [[ME-2998](https://mysocket.atlassian.net/browse/ME-2998)] Add List Services Permissions to Connector K8S

Required for k8s service discovery.

[ME-2998]: https://mysocket.atlassian.net/browse/ME-2998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ