### PR TITLE
[ME-3868] Allow Inbound UDP Traffic to WireGuard Port (CFN Templates)

### DIFF
--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -145,8 +145,14 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
+        - Description: Allow outbound traffic to all destinations and protocols
+          CidrIp: 0.0.0.0/0
           IpProtocol: -1
+      SecurityGroupIngress:
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+          CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
 
   ConnectorInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/cloudformation-templates/aws_connector_installer_insecure/template.yaml
+++ b/cloudformation-templates/aws_connector_installer_insecure/template.yaml
@@ -114,8 +114,14 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
+        - Description: Allow outbound traffic to all destinations and protocols
+          CidrIp: 0.0.0.0/0
           IpProtocol: -1
+      SecurityGroupIngress:
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+          CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
 
   ConnectorInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/cloudformation-templates/aws_connector_installer_invite/template.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/template.yaml
@@ -130,8 +130,14 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
+        - Description: Allow outbound traffic to all destinations and protocols
+          CidrIp: 0.0.0.0/0
           IpProtocol: -1
+      SecurityGroupIngress:
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+          CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
 
   ConnectorInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'


### PR DESCRIPTION
## [[ME-3868](https://mysocket.atlassian.net/browse/ME-3868)] Allow Inbound UDP Traffic to WireGuard Port (CFN Templates)

[ME-3868]: https://mysocket.atlassian.net/browse/ME-3868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ