### PR TITLE
[ME-3869] IPv6 Support in Connector CFN Templates

### DIFF
--- a/cloudformation-templates/aws_connector_installer/template.yaml
+++ b/cloudformation-templates/aws_connector_installer/template.yaml
@@ -145,12 +145,19 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - Description: Allow outbound traffic to all destinations and protocols
+        - Description: Allow outbound traffic to all destinations and protocols over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
+        - Description: Allow outbound traffic to all destinations and protocols over IPv6
+          CidrIp: ::/0
+          IpProtocol: -1
       SecurityGroupIngress:
-        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
+          CidrIpv6: ::/0
           IpProtocol: udp
           ToPort: 32442
 
@@ -175,6 +182,7 @@ Resources:
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
+            Ipv6AddressCount: 1  # automatically assign one IPv6 address
         UserData:
           Fn::Base64:
             !Sub |

--- a/cloudformation-templates/aws_connector_installer_insecure/template.yaml
+++ b/cloudformation-templates/aws_connector_installer_insecure/template.yaml
@@ -114,12 +114,19 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - Description: Allow outbound traffic to all destinations and protocols
+        - Description: Allow outbound traffic to all destinations and protocols over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
+        - Description: Allow outbound traffic to all destinations and protocols over IPv6
+          CidrIp: ::/0
+          IpProtocol: -1
       SecurityGroupIngress:
-        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
+          CidrIpv6: ::/0
           IpProtocol: udp
           ToPort: 32442
 
@@ -144,6 +151,7 @@ Resources:
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
+            Ipv6AddressCount: 1  # automatically assign one IPv6 address
         UserData:
           Fn::Base64:
             !Sub |

--- a/cloudformation-templates/aws_connector_installer_invite/template.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/template.yaml
@@ -130,12 +130,19 @@ Resources:
       GroupDescription: Security Group for instance with only egress allowed
       VpcId: !Ref VpcId
       SecurityGroupEgress:
-        - Description: Allow outbound traffic to all destinations and protocols
+        - Description: Allow outbound traffic to all destinations and protocols over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
+        - Description: Allow outbound traffic to all destinations and protocols over IPv6
+          CidrIp: ::/0
+          IpProtocol: -1
       SecurityGroupIngress:
-        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          ToPort: 32442
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
+          CidrIpv6: ::/0
           IpProtocol: udp
           ToPort: 32442
 
@@ -160,6 +167,7 @@ Resources:
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
+            Ipv6AddressCount: 1  # automatically assign one IPv6 address
         UserData:
           Fn::Base64:
             !Sub |


### PR DESCRIPTION
## [[ME-3869](https://mysocket.atlassian.net/browse/ME-3869)] IPv6 Support in Connector CFN Templates


[ME-3869]: https://mysocket.atlassian.net/browse/ME-3869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ