### PR TITLE
[ME-4028] Add FromPort to CFN Connector Installer Security Group Rules

### DIFF
--- a/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
+++ b/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
@@ -13,9 +13,21 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: The ID of the Subnet where to run the connector
 
-  Border0Token:
-    Type: String 
-    Description: The Border0 token (which the connector instance uses to authenticate against your Border0 organization)
+  InstanceType:
+    Type: String
+    Description: The EC2 Instance Type for the connector instance
+    Default: t4g.nano
+
+  Border0TokenSsmParameter:
+    Type: AWS::SSM::Parameter::Name
+    Description: The name/path of the SSM parameter for the Border0 token (which the connector instance uses to authenticate against your Border0 organization)
+
+####################################
+##           CONDITIONS           ##
+####################################
+Conditions:
+
+  Border0TokenSsmParameterStartsWithSlash: !Equals [ !Select [ 0, !Split [ "/", !Ref Border0TokenSsmParameter ] ], "" ]
 
 ####################################
 ##           RESOURCES            ##
@@ -68,6 +80,25 @@ Resources:
                   - 'eks:ListClusters'
                   - 'eks:DescribeCluster'
                 Resource: '*'
+        # SSM Parameter ReadOnly access to the SSM parameter of the connector's token.
+        - PolicyName: AccessToBorder0TokenSsmParameter
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ssm:DescribeParameters'
+                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameter'
+                  - 'ssm:GetParameters'
+                Resource:
+                  # SSM parameters can begin with a slash character '/'. When they begin
+                  # with a slash character, it must be ommitted from the resource ARN here.
+                  Fn::Sub:
+                    - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmParameterPath}
+                    - SsmParameterPath:
+                        !If [Border0TokenSsmParameterStartsWithSlash, !Sub "${Border0TokenSsmParameter}", !Sub "/${Border0TokenSsmParameter}"]
         # Allow generating temporary user credentials for database IAM access.
         - PolicyName: GenerateTemporaryDatabaseCredsForRds
           PolicyDocument:
@@ -118,16 +149,18 @@ Resources:
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
         - Description: Allow outbound traffic to all destinations and protocols over IPv6
-          CidrIp: ::/0
+          CidrIpv6: ::/0
           IpProtocol: -1
       SecurityGroupIngress:
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
           CidrIpv6: ::/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
 
   ConnectorInstanceProfile:
@@ -144,14 +177,14 @@ Resources:
         IamInstanceProfile:
           Arn: !GetAtt ConnectorInstanceProfile.Arn
         ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
-        InstanceType: "t4g.nano"
+        InstanceType: !Ref InstanceType
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
-            Ipv6AddressCount: 1  # automatically assign one IPv6 address
+            # Ipv6AddressCount: 1  # uncomment to automatically assign one IPv6 address, subnet must have IPv6 range(s).
         UserData:
           Fn::Base64:
             !Sub |
@@ -160,7 +193,7 @@ Resources:
               sudo yum install -y iptables
               sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
               sudo chmod +x /usr/local/bin/border0
-              sudo border0 connector install --daemon-only --token ${Border0Token}
+              sudo border0 connector install --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'

--- a/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
+++ b/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
@@ -13,21 +13,9 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: The ID of the Subnet where to run the connector
 
-  InstanceType:
-    Type: String
-    Description: The EC2 Instance Type for the connector instance
-    Default: t4g.nano
-
-  Border0TokenSsmParameter:
-    Type: AWS::SSM::Parameter::Name
-    Description: The name/path of the SSM parameter for the Border0 token (which the connector instance uses to authenticate against your Border0 organization)
-
-####################################
-##           CONDITIONS           ##
-####################################
-Conditions:
-
-  Border0TokenSsmParameterStartsWithSlash: !Equals [ !Select [ 0, !Split [ "/", !Ref Border0TokenSsmParameter ] ], "" ]
+  Border0Token:
+    Type: String 
+    Description: The Border0 token (which the connector instance uses to authenticate against your Border0 organization)
 
 ####################################
 ##           RESOURCES            ##
@@ -80,25 +68,6 @@ Resources:
                   - 'eks:ListClusters'
                   - 'eks:DescribeCluster'
                 Resource: '*'
-        # SSM Parameter ReadOnly access to the SSM parameter of the connector's token.
-        - PolicyName: AccessToBorder0TokenSsmParameter
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: 'ssm:DescribeParameters'
-                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
-              - Effect: Allow
-                Action:
-                  - 'ssm:GetParameter'
-                  - 'ssm:GetParameters'
-                Resource:
-                  # SSM parameters can begin with a slash character '/'. When they begin
-                  # with a slash character, it must be ommitted from the resource ARN here.
-                  Fn::Sub:
-                    - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${SsmParameterPath}
-                    - SsmParameterPath:
-                        !If [Border0TokenSsmParameterStartsWithSlash, !Sub "${Border0TokenSsmParameter}", !Sub "/${Border0TokenSsmParameter}"]
         # Allow generating temporary user credentials for database IAM access.
         - PolicyName: GenerateTemporaryDatabaseCredsForRds
           PolicyDocument:
@@ -149,16 +118,18 @@ Resources:
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
         - Description: Allow outbound traffic to all destinations and protocols over IPv6
-          CidrIp: ::/0
+          CidrIpv6: ::/0
           IpProtocol: -1
       SecurityGroupIngress:
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
           CidrIpv6: ::/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
 
   ConnectorInstanceProfile:
@@ -175,14 +146,14 @@ Resources:
         IamInstanceProfile:
           Arn: !GetAtt ConnectorInstanceProfile.Arn
         ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
-        InstanceType: !Ref InstanceType
+        InstanceType: "t4g.nano"
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
-            Ipv6AddressCount: 1  # automatically assign one IPv6 address
+            # Ipv6AddressCount: 1  # uncomment to automatically assign one IPv6 address, subnet must have IPv6 range(s).
         UserData:
           Fn::Base64:
             !Sub |
@@ -191,7 +162,7 @@ Resources:
               sudo yum install -y iptables
               sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
               sudo chmod +x /usr/local/bin/border0
-              sudo border0 connector install --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
+              sudo border0 connector install --daemon-only --token ${Border0Token}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'

--- a/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
@@ -134,16 +134,18 @@ Resources:
           CidrIp: 0.0.0.0/0
           IpProtocol: -1
         - Description: Allow outbound traffic to all destinations and protocols over IPv6
-          CidrIp: ::/0
+          CidrIpv6: ::/0
           IpProtocol: -1
       SecurityGroupIngress:
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
         - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
           CidrIpv6: ::/0
           IpProtocol: udp
+          FromPort: 32442
           ToPort: 32442
 
   ConnectorInstanceProfile:
@@ -167,7 +169,7 @@ Resources:
             DeleteOnTermination: true
             Groups:
             - !Ref ConnectorInstanceSecurityGroup
-            Ipv6AddressCount: 1  # automatically assign one IPv6 address
+            # Ipv6AddressCount: 1  # uncomment to automatically assign one IPv6 address, subnet must have IPv6 range(s).
         UserData:
           Fn::Base64:
             !Sub |


### PR DESCRIPTION
## [[ME-4028](https://mysocket.atlassian.net/browse/ME-4028)] Add FromPort to CFN Connector Installer Security Group Rules

- The `FromPort` is required when `ToPort` is defined
- Fixes typo in security group rule using a v6 range in a v4 field
- Comments out the line that assigns a v6 to instances automatically - this will cause the template to fail in subnets without v6 ranges (so its up to the customer to uncomment it in prod-like envs)
- Also renames files to match name in S3 bucket (for identification purposes)

[ME-4028]: https://mysocket.atlassian.net/browse/ME-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ