### PR TITLE
[ME-4042] Bump Default Instance Types on Connector Templates

### DIFF
--- a/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
+++ b/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
@@ -13,10 +13,15 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: The ID of the Subnet where to run the connector
 
+  # t4g.nano  : 2 vCPU, 0.5 GiB, US$0.0042/hr ~= US$3.03/mo  (on-demand pricing)
+  # t4g.micro : 2 vCPU, 1.0 GiB, US$0.0084/hr ~= US$6.05/mo  (on-demand pricing)
+  # t4g.small : 2 vCPU, 2.0 GiB, US$0.0168/hr ~= US$12.10/mo (on-demand pricing)
+  #
+  # https://aws.amazon.com/ec2/pricing/on-demand/
   InstanceType:
     Type: String
-    Description: The EC2 Instance Type for the connector instance
-    Default: t4g.nano
+    Description: The EC2 Instance Type for the connector instance (> t4g.micro recommended)
+    Default: t4g.micro
 
   Border0TokenSsmParameter:
     Type: AWS::SSM::Parameter::Name

--- a/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
+++ b/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
@@ -13,6 +13,16 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: The ID of the Subnet where to run the connector
 
+  # t4g.nano  : 2 vCPU, 0.5 GiB, US$0.0042/hr ~= US$3.03/mo  (on-demand pricing)
+  # t4g.micro : 2 vCPU, 1.0 GiB, US$0.0084/hr ~= US$6.05/mo  (on-demand pricing)
+  # t4g.small : 2 vCPU, 2.0 GiB, US$0.0168/hr ~= US$12.10/mo (on-demand pricing)
+  #
+  # https://aws.amazon.com/ec2/pricing/on-demand/
+  InstanceType:
+    Type: String
+    Description: The EC2 Instance Type for the connector instance (> t4g.micro recommended)
+    Default: t4g.micro
+
   Border0Token:
     Type: String 
     Description: The Border0 token (which the connector instance uses to authenticate against your Border0 organization)
@@ -146,7 +156,7 @@ Resources:
         IamInstanceProfile:
           Arn: !GetAtt ConnectorInstanceProfile.Arn
         ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
-        InstanceType: "t4g.nano"
+        InstanceType: !Ref InstanceType
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true

--- a/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
@@ -13,10 +13,15 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
     Description: The ID of the Subnet where to run the connector
 
+  # t4g.nano  : 2 vCPU, 0.5 GiB, US$0.0042/hr ~= US$3.03/mo  (on-demand pricing)
+  # t4g.micro : 2 vCPU, 1.0 GiB, US$0.0084/hr ~= US$6.05/mo  (on-demand pricing)
+  # t4g.small : 2 vCPU, 2.0 GiB, US$0.0168/hr ~= US$12.10/mo (on-demand pricing)
+  #
+  # https://aws.amazon.com/ec2/pricing/on-demand/
   InstanceType:
     Type: String
-    Description: The EC2 Instance Type for the connector instance
-    Default: t4g.nano
+    Description: The EC2 Instance Type for the connector instance (> t4g.micro recommended)
+    Default: t4g.micro
 
   InviteCode:
     Type: String


### PR DESCRIPTION
## [[ME-4042](https://mysocket.atlassian.net/browse/ME-4042)] Bump Default Instance Types on Connector Templates

Issues while upgrading where reported (t4g.nano may not have enough memory to hold the binary's copy in memory while upgrading).

```
[root@ip-172-31-35-20 ~]# border0 version upgrade
Upgrading /usr/local/bin/border0 to version v1.1-1290-ga5788a4a
[========================================] 100.0% (120.38/120.38 MB)
Killed
[root@ip-172-31-35-20 ~]# echo $?
137
[root@ip-172-31-35-20 ~]# free -h
               total        used        free      shared  buff/cache   available
Mem:           419Mi       111Mi       186Mi        27Mi       120Mi       270Mi
Swap:          418Mi        69Mi       349Mi
```

[ME-4042]: https://mysocket.atlassian.net/browse/ME-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ