### PR TITLE
[ME-4070] Update Connector K8s Templates for VPN Use Case

### DIFF
--- a/kubernetes-templates/connector_for_k8s_api_sck/connector.yaml
+++ b/kubernetes-templates/connector_for_k8s_api_sck/connector.yaml
@@ -40,6 +40,7 @@ data:
   config.yaml: |
     # e.g. token: eyJhbGciOiJIUzI1NiIsIn...
     token: [[ YOUR TOKEN GOES HERE ]]
+    device_state_path: /etc/border0-device/state.yaml
 
 ---
 apiVersion: apps/v1
@@ -66,8 +67,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/border0-connector
+            - name: dev-net-tun
+              mountPath: /dev/net/tun
+          securityContext:
+            capabilities:
+              add: [ NET_ADMIN, NET_RAW ] # NET_RAW is not used today but we anticipate using it in the future.
       volumes:
         - name: config
           configMap:
             name: connector-config
-
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun

--- a/kubernetes-templates/connector_in_k8s/connector.yaml
+++ b/kubernetes-templates/connector_in_k8s/connector.yaml
@@ -47,6 +47,7 @@ data:
   config.yaml: |
     # e.g. token: eyJhbGciOiJIUzI1NiIsIn...
     token: [[ YOUR TOKEN GOES HERE ]]
+    device_state_path: /etc/border0-device/state.yaml
 
 ---
 apiVersion: apps/v1
@@ -73,8 +74,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/border0-connector
+            - name: dev-net-tun
+              mountPath: /dev/net/tun
+          securityContext:
+            capabilities:
+              add: [ NET_ADMIN, NET_RAW ] # NET_RAW is not used today but we anticipate using it in the future.
       volumes:
         - name: config
           configMap:
             name: connector-config
-
+        - name: dev-net-tun
+          hostPath:
+            path: /dev/net/tun


### PR DESCRIPTION
## [[ME-4070](https://mysocket.atlassian.net/browse/ME-4070)] Update Connector K8s Templates for VPN Use Case

- Supports running vpn-enabled connector in kubernetes.

> Note: the connector currently does not need cap `NET_RAW`, but we anticipating needing it in the future (for use of raw network sockets e.g. if we ever do software NAT, etc).

[ME-4070]: https://mysocket.atlassian.net/browse/ME-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ