### PR TITLE
[ME-4070] Enable Network Sockets in K8s Connector Templates

### DIFF
--- a/kubernetes-templates/connector_for_k8s_api_sck/connector.yaml
+++ b/kubernetes-templates/connector_for_k8s_api_sck/connector.yaml
@@ -70,6 +70,7 @@ spec:
             - name: dev-net-tun
               mountPath: /dev/net/tun
           securityContext:
+            privileged: true # required to create TUN iface.
             capabilities:
               add: [ NET_ADMIN, NET_RAW ] # NET_RAW is not used today but we anticipate using it in the future.
       volumes:

--- a/kubernetes-templates/connector_in_k8s/connector.yaml
+++ b/kubernetes-templates/connector_in_k8s/connector.yaml
@@ -77,6 +77,7 @@ spec:
             - name: dev-net-tun
               mountPath: /dev/net/tun
           securityContext:
+            privileged: true # required to create TUN iface.
             capabilities:
               add: [ NET_ADMIN, NET_RAW ] # NET_RAW is not used today but we anticipate using it in the future.
       volumes:


### PR DESCRIPTION
## [[ME-4070](https://mysocket.atlassian.net/browse/ME-4070)] Enable Network Sockets in K8s Connector Templates

This is required for network sockets e.g. subnet routers and exit nodes to work properly. Otherwise fails to create TUN interface, even with all the right mounts.

[ME-4070]: https://mysocket.atlassian.net/browse/ME-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ