### PR TITLE
[ME-4278] Update CFN Templates to Allow for Opening VPC Endpoint Tunnels

### DIFF
--- a/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
+++ b/cloudformation-templates/aws_connector_installer/aws-connector-v2-installer.yaml
@@ -120,6 +120,14 @@ Resources:
               - Effect: Allow
                 Action: 'ec2-instance-connect:SendSSHPublicKey'
                 Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+        # Allow opening tunnels to any ec2 instance connect endpoint (for ec2 instance connect).
+        - PolicyName: OpenTunnelsToEc2InstanceConnectEndpoints
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:OpenTunnel'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance-connect-endpoint/*'
         # Allow starting and terminating ssm sessions to any instance (for ssm)
         - PolicyName: StartAndTerminateSsmSessions
           PolicyDocument:

--- a/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
+++ b/cloudformation-templates/aws_connector_installer_insecure/aws-connector-v2-installer-insecure.yaml
@@ -94,6 +94,14 @@ Resources:
               - Effect: Allow
                 Action: 'ec2-instance-connect:SendSSHPublicKey'
                 Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+        # Allow opening tunnels to any ec2 instance connect endpoint (for ec2 instance connect).
+        - PolicyName: OpenTunnelsToEc2InstanceConnectEndpoints
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:OpenTunnel'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance-connect-endpoint/*'
         # Allow starting and terminating ssm sessions to any instance (for ssm)
         - PolicyName: StartAndTerminateSsmSessions
           PolicyDocument:

--- a/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml
@@ -105,6 +105,14 @@ Resources:
               - Effect: Allow
                 Action: 'ec2-instance-connect:SendSSHPublicKey'
                 Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+        # Allow opening tunnels to any ec2 instance connect endpoint (for ec2 instance connect).
+        - PolicyName: OpenTunnelsToEc2InstanceConnectEndpoints
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:OpenTunnel'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance-connect-endpoint/*'
         # Allow starting and terminating ssm sessions to any instance (for ssm)
         - PolicyName: StartAndTerminateSsmSessions
           PolicyDocument:


### PR DESCRIPTION
## [[ME-4278](https://mysocket.atlassian.net/browse/ME-4276)] Update CFN Templates to Allow for Opening VPC Endpoint Tunnels

Adds permissions as per https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/permissions-for-ec2-instance-connect-endpoint.html#iam-OpenTunnel

[ME-4278]: https://mysocket.atlassian.net/browse/ME-4278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ