### PR TITLE
[ME-4351] Expiring Policies Example

### DIFF
--- a/api-call-examples/expiring_policies/Makefile
+++ b/api-call-examples/expiring_policies/Makefile
@@ -1,0 +1,18 @@
+run: create-venv
+	. experiment-env/bin/activate; \
+	pip3 install -r requirements.txt; \
+	python3 main.py
+
+create-venv:
+	@if [ -z "$$VIRTUAL_ENV" ] || [ "$$(basename $$VIRTUAL_ENV)" != "experiment-env" ]; then \
+		echo "The 'experiment-env' virtual environment is not activated, setting up..."; \
+		python3 -m venv experiment-env; \
+	else \
+		echo "The 'experiment-env' virtual environment is already activated, skipping setup..."; \
+	fi
+
+clean:
+	@rm -rf experiment-env
+	@rm -rf __pycache__
+	@rm -rf .ipynb_checkpoints
+	@echo "Cleaned up the virtual environment and temporary files."

--- a/api-call-examples/expiring_policies/README.md
+++ b/api-call-examples/expiring_policies/README.md
@@ -1,0 +1,11 @@
+# Expiring Policies
+
+Simply export your Border0 API (with admin privileges) as:
+
+```
+export BORDER0_API_TOKEN=eyJhbGciOiJIUzI1.....
+```
+
+and run `make`.
+
+Adjust the code to change the policy's name, expiry, and body as needed.

--- a/api-call-examples/expiring_policies/main.py
+++ b/api-call-examples/expiring_policies/main.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import time
+import requests
+
+ENV_BORDER0_TOKEN = "BORDER0_TOKEN"
+ENV_BORDER0_API_URL = "BORDER0_API_URL"
+
+def create_policy(token: str, name: str, policy_data: dict, expiry: int):
+    response = requests.post(
+        url=f"{os.environ.get(ENV_BORDER0_API_URL, "https://api.border0.com/api/v1")}/policies",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "name": name,
+            "description": "Test policy for expiring-policies demo",
+            "socket_ids": [], # none
+            "org_wide": False,
+            "policy_data": policy_data,
+            "version": "v2",
+            "expiry": expiry,
+        },
+    )
+    if response.status_code == 201:
+        print("Policy created successfully!")
+    else:
+        print(f"Failed to create policy: {response.status_code}")
+        try:
+            print(response.json())
+        except json.JSONDecodeError:
+            print(response.text)
+
+def get_policy_data(email: str) -> dict:
+    return {
+        "condition": {
+            "who": {
+                "email": [ email ],
+                "group": [],
+                "service_account": []
+            }
+        },
+        "permissions": {
+            "database": {},
+            "http": {},
+            "kubernetes": {},
+            "network": {},
+            "rdp": {},
+            "ssh": {
+                "docker_exec": {},
+                "exec": {},
+                "kubectl_exec": {},
+                "sftp": {},
+                "shell": {},
+                "tcp_forwarding": {}
+            },
+            "tls": {},
+            "vnc": {}
+        }
+    }
+
+if __name__ == "__main__":
+    token = os.environ.get(ENV_BORDER0_TOKEN, '')
+    if not token:
+        raise Exception(f"Required environment variable {ENV_BORDER0_TOKEN} is not set")
+    
+    now_unix = int(time.time())
+
+    create_policy(
+        token=token,
+        name=f"my-test-policy-{now_unix}",
+        policy_data=get_policy_data("adriano@border0.com"),
+        expiry=now_unix+5*60, # expire 5 minutes from now
+    )

--- a/api-call-examples/expiring_policies/requirements.txt
+++ b/api-call-examples/expiring_policies/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## [[ME-4351](https://mysocket.atlassian.net/browse/ME-4531)] Expiring Policies Example

Simply export your Border0 API (with admin privileges) as:

```
export BORDER0_API_TOKEN=eyJhbGciOiJIUzI1.....
```

and run `make`.

Adjust the code to change the policy's name, expiry, and body as needed.

### Example Run:

```
✔ ~/go/src/github.com/borderzero/examples/api-call-examples/expiring_policies [main]
10:43 $ make
The 'experiment-env' virtual environment is not activated, setting up...
. experiment-env/bin/activate; \
	pip3 install -r requirements.txt; \
	python3 main.py
Requirement already satisfied: requests in ./experiment-env/lib/python3.13/site-packages (from -r requirements.txt (line 1)) (2.32.3)
Requirement already satisfied: charset-normalizer<4,>=2 in ./experiment-env/lib/python3.13/site-packages (from requests->-r requirements.txt (line 1)) (3.4.2)
Requirement already satisfied: idna<4,>=2.5 in ./experiment-env/lib/python3.13/site-packages (from requests->-r requirements.txt (line 1)) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./experiment-env/lib/python3.13/site-packages (from requests->-r requirements.txt (line 1)) (2.4.0)
Requirement already satisfied: certifi>=2017.4.17 in ./experiment-env/lib/python3.13/site-packages (from requests->-r requirements.txt (line 1)) (2025.4.26)

[notice] A new release of pip is available: 25.0.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
Policy created successfully!
```

![Screenshot 2025-05-06 at 10 49 30 AM](https://github.com/user-attachments/assets/79f5340b-3fc9-4627-8974-50245a6a749b)


[ME-4351]: https://mysocket.atlassian.net/browse/ME-4351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ