### PR TITLE
[ME-5437] Use Production URLs for Header Signing Examples

### DIFF
--- a/httpsig/README.md
+++ b/httpsig/README.md
@@ -6,7 +6,7 @@ Verify Ed25519 signatures on HTTP requests signed by Border0/OpenResty.
 
 ```bash
 cd go
-go run main.go --jwks_url https://signing.staging.border0.io/keys
+go run main.go --jwks_url https://signing.border0.io/keys
 ```
 
 Server runs on `:8080` and verifies all incoming requests.

--- a/httpsig/go/README.md
+++ b/httpsig/go/README.md
@@ -3,7 +3,7 @@
 ## Run
 
 ```bash
-go run main.go --jwks_url https://signing.staging.border0.io/keys
+go run main.go --jwks_url https://signing.border0.io/keys
 ```
 
 Server listens on `:8080` and verifies Ed25519 signatures on all requests.
@@ -12,7 +12,7 @@ Server listens on `:8080` and verifies Ed25519 signatures on all requests.
 
 ```go
 // Load keys from JWKS
-publicKeys, _ := loadPublicKeysFromJWKS("https://signing.staging.border0.io/keys")
+publicKeys, _ := loadPublicKeysFromJWKS("https://signing.border0.io/keys")
 
 // Create handler
 handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/httpsig/go/main.go
+++ b/httpsig/go/main.go
@@ -195,7 +195,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage:\n")
 		fmt.Fprintf(os.Stderr, "  %s --jwks_url <https://example.com/.well-known/jwks.json>\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "\nExample:\n")
-		fmt.Fprintf(os.Stderr, "  %s --jwks_url https://signing.staging.border0.io/keys\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s --jwks_url https://signing.border0.io/keys\n", os.Args[0])
 		os.Exit(1)
 	}
 

--- a/httpsig/php/README.md
+++ b/httpsig/php/README.md
@@ -20,7 +20,7 @@ All requests are verified before processing.
 require_once 'verify_signature.php';
 
 // Initialize with JWKS URL
-$verifier = new SignatureVerifier('https://signing.staging.border0.io/keys');
+$verifier = new SignatureVerifier('https://signing.border0.io/keys');
 $verifier->loadPublicKeysFromJWKS();
 
 // Verify current request

--- a/httpsig/php/middleware_example.php
+++ b/httpsig/php/middleware_example.php
@@ -74,7 +74,7 @@ function signatureMiddleware($jwksUrl)
 // ============================================================================
 
 // Apply signature verification middleware
-signatureMiddleware('https://signing.staging.border0.io/keys');
+signatureMiddleware('https://signing.border0.io/keys');
 
 // If we reach here, the signature was verified successfully!
 

--- a/httpsig/php/verify_signature.php
+++ b/httpsig/php/verify_signature.php
@@ -289,7 +289,7 @@ class SignatureVerifier
 function verifyWithJWKS()
 {
     try {
-        $verifier = new SignatureVerifier('https://signing.staging.border0.io/keys');
+        $verifier = new SignatureVerifier('https://signing.border0.io/keys');
         $verifier->loadPublicKeysFromJWKS();
 
         $result = $verifier->verifyCurrentRequest();


### PR DESCRIPTION
## [[ME-5437](https://mysocket.atlassian.net/browse/ME-5437)] Use Production URLs for Header Signing Examples

Ran `rg -l "signing.staging" | xargs sed -i '' 's|signing.staging|signing|g'`

[ME-5437]: https://mysocket.atlassian.net/browse/ME-5437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ