### PR TITLE
[ME-5727] Add AWS CFN Installer for Tailzero

### DIFF
--- a/cloudformation-templates/aws_connector_installer_invite/aws-tailzero-installer-invite.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/aws-tailzero-installer-invite.yaml
@@ -1,0 +1,233 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+####################################
+##           PARAMETERS           ##
+####################################
+Parameters:
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: The ID of the VPC where to run the connector
+
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: The ID of the Subnet where to run the connector
+
+  # t4g.nano  : 2 vCPU, 0.5 GiB, US$0.0042/hr ~= US$3.03/mo  (on-demand pricing)
+  # t4g.micro : 2 vCPU, 1.0 GiB, US$0.0084/hr ~= US$6.05/mo  (on-demand pricing)
+  # t4g.small : 2 vCPU, 2.0 GiB, US$0.0168/hr ~= US$12.10/mo (on-demand pricing)
+  #
+  # https://aws.amazon.com/ec2/pricing/on-demand/
+  InstanceType:
+    Type: String
+    Description: The EC2 Instance Type for the connector instance (> t4g.micro recommended)
+    Default: t4g.micro
+
+  InviteCode:
+    Type: String
+    Description: The Border0 Connector invite code for the connector
+
+####################################
+##           RESOURCES            ##
+####################################
+Resources:
+
+  ConnectorInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess'
+        - 'arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedEC2InstanceDefaultPolicy' # allows SSM access to connector instances as breakglass
+      Policies:
+        # ECS ReadOnly Policy for ECS discovery and providing Border0 clients
+        # with the menu with all available tasks and containers in ecs service.
+        - PolicyName: AmazonECSReadOnlyAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ecs:DescribeClusters'
+                  - 'ecs:DescribeContainerInstances'
+                  - 'ecs:DescribeServices'
+                  - 'ecs:DescribeTaskDefinition'
+                  - 'ecs:DescribeTasks'
+                  - 'ecs:ListClusters'
+                  - 'ecs:ListContainerInstances'
+                  - 'ecs:ListServices'
+                  - 'ecs:ListTaskDefinitionFamilies'
+                  - 'ecs:ListTaskDefinitions'
+                  - 'ecs:ListTasks'
+                Resource: '*'
+        # EKS ReadOnly Policy for EKS discovery
+        - PolicyName: AmazonEKSReadOnlyAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'eks:ListClusters'
+                  - 'eks:DescribeCluster'
+                Resource: '*'
+        # SSM Parameter ReadOnly access to the SSM parameter of the connector's token.
+        - PolicyName: AccessToBorder0TokenSsmParameter
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:PutParameter'
+                  - 'ssm:GetParameter'
+                  - 'ssm:GetParameters'
+                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/border0/connector-tokens/for-invite-${InviteCode}'
+        # Allow generating temporary user credentials for database IAM access.
+        - PolicyName: GenerateTemporaryDatabaseCredsForRds
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'rds-db:connect'
+                Resource: !Sub 'arn:aws:rds-db:*:${AWS::AccountId}:dbuser:*'
+        # Allow sending public keys to any ec2 instance (for ec2 instance connect).
+        - PolicyName: SendSshPublicKeysToEc2Instances
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:SendSSHPublicKey'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+        # Allow opening tunnels to any ec2 instance connect endpoint (for ec2 instance connect).
+        - PolicyName: OpenTunnelsToEc2InstanceConnectEndpoints
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ec2-instance-connect:OpenTunnel'
+                Resource: !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance-connect-endpoint/*'
+        # Allow starting and terminating ssm sessions + sending commands to any instance (for ssm)
+        - PolicyName: StartAndTerminateSsmSessions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ssm:StartSession'
+                Resource:
+                  - !Sub 'arn:aws:ecs:*:${AWS::AccountId}:task/*'
+                  - !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+                  - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession' # legacy
+                  - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/SSM-SessionManagerRunShell'
+              - Effect: Allow
+                Action: 'ssm:SendCommand'
+                Resource:
+                  - !Sub 'arn:aws:ecs:*:${AWS::AccountId}:task/*'
+                  - !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
+                  - 'arn:aws:ssm:*::document/AWS-RunShellScript'
+                  - 'arn:aws:ssm:*::document/AWS-RunPowerShellScript' # for windows targets
+              - Effect: Allow
+                Action: 'ssm:GetCommandInvocation'
+                Resource: !Sub 'arn:aws:ssm:*:${AWS::AccountId}:*'
+              - Effect: Allow
+                Action: 'ssm:TerminateSession'
+                Resource:
+                  - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:session/*'
+        # Allow the EC2 discoverer to check EC2 instances' SSM status (e.g. registered with ssm or not)
+        - PolicyName: DescribeInstancesSsmStatus
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'ssm:DescribeInstanceInformation'
+                Resource: !Sub 'arn:aws:ssm:*:${AWS::AccountId}:*'
+
+  ConnectorInstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for instance with only egress allowed
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - Description: Allow outbound traffic to all destinations and protocols over IPv4
+          CidrIp: 0.0.0.0/0
+          IpProtocol: -1
+        - Description: Allow outbound traffic to all destinations and protocols over IPv6
+          CidrIpv6: ::/0
+          IpProtocol: -1
+      SecurityGroupIngress:
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
+          CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          FromPort: 32442
+          ToPort: 32442
+        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
+          CidrIpv6: ::/0
+          IpProtocol: udp
+          FromPort: 32442
+          ToPort: 32442
+
+  ConnectorInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Roles:
+        - !Ref ConnectorInstanceRole
+
+  ConnectorInstanceLaunchTemplate:
+    Type: 'AWS::EC2::LaunchTemplate'
+    Properties:
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt ConnectorInstanceProfile.Arn
+        ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
+        InstanceType: !Ref InstanceType
+        NetworkInterfaces:
+          - DeviceIndex: 0
+            AssociatePublicIpAddress: true
+            DeleteOnTermination: true
+            Groups:
+            - !Ref ConnectorInstanceSecurityGroup
+            # Ipv6AddressCount: 1  # uncomment to automatically assign one IPv6 address, subnet must have IPv6 range(s).
+        UserData:
+          Fn::Base64:
+            !Sub |
+              #!/bin/bash -xe
+              sudo yum update -y
+              sudo yum install -y iptables
+              sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
+              sudo chmod +x /usr/local/bin/border0
+              export AWS_REGION="${AWS::Region}"
+              sudo -E border0 connector install --daemon-only --invite ${InviteCode} --token-persistence-ssm-path /border0/connector-tokens/for-invite-${InviteCode}
+
+  ConnectorInstanceAutoScalingGroup:
+    Type: 'AWS::AutoScaling::AutoScalingGroup'
+    Properties:
+      MinSize: '1'
+      MaxSize: '1'
+      DesiredCapacity: '1'
+      Tags:
+        - Key: Name
+          Value: Border0-Connector
+          PropagateAtLaunch: true
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ConnectorInstanceLaunchTemplate
+        Version: !GetAtt ConnectorInstanceLaunchTemplate.LatestVersionNumber
+      VPCZoneIdentifier:
+        - !Ref SubnetId
+      MetricsCollection:
+        - Granularity: '1Minute'
+          Metrics:
+            - GroupMinSize
+            - GroupMaxSize
+            - GroupDesiredCapacity
+            - GroupInServiceInstances
+            - GroupPendingInstances
+            - GroupStandbyInstances
+            - GroupTerminatingInstances
+            - GroupTotalInstances

--- a/cloudformation-templates/aws_connector_installer_invite/aws-tailzero-installer-invite.yaml
+++ b/cloudformation-templates/aws_connector_installer_invite/aws-tailzero-installer-invite.yaml
@@ -161,16 +161,16 @@ Resources:
           CidrIpv6: ::/0
           IpProtocol: -1
       SecurityGroupIngress:
-        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv4
+        - Description: Allow inbound WireGuard (udp) traffic for Tailzero Connector (tsnet) over IPv4
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
-          FromPort: 32442
-          ToPort: 32442
-        - Description: Allow inbound WireGuard (udp) traffic for Border0 Connector over IPv6
+          FromPort: 41641
+          ToPort: 41641
+        - Description: Allow inbound WireGuard (udp) traffic for Tailzero Connector (tsnet) over IPv6
           CidrIpv6: ::/0
           IpProtocol: udp
-          FromPort: 32442
-          ToPort: 32442
+          FromPort: 41641
+          ToPort: 41641
 
   ConnectorInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -198,12 +198,10 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -xe
-              sudo yum update -y
-              sudo yum install -y iptables
-              sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
-              sudo chmod +x /usr/local/bin/border0
               export AWS_REGION="${AWS::Region}"
-              sudo -E border0 connector install --daemon-only --invite ${InviteCode} --token-persistence-ssm-path /border0/connector-tokens/for-invite-${InviteCode}
+              curl -fsSL https://tailscale.border0.com/tailzero/install.sh | sh -s -- \
+                --invite ${InviteCode} \
+                --cache-ssm-path /border0/connector-tokens/for-invite-${InviteCode}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'


### PR DESCRIPTION
## [[ME-5727](https://mysocket.atlassian.net/browse/ME-5727)] Add AWS CFN Installer for Tailzero

The template is exactly the same as `./cloudformation-templates/aws_connector_installer_invite/aws-connector-v2-installer-invite.yaml` except for the EC2 Launch Template's user data (which downloads and installs tailzero, instead of border0).

[ME-5727]: https://mysocket.atlassian.net/browse/ME-5727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ